### PR TITLE
Update Cerebras.py: add "deepseek-r1-distill-llama-70b" to the models…

### DIFF
--- a/g4f/Provider/needs_auth/Cerebras.py
+++ b/g4f/Provider/needs_auth/Cerebras.py
@@ -17,9 +17,10 @@ class Cerebras(OpenaiAPI):
     models = [
         default_model,
         "llama3.1-8b",
-        "llama-3.3-70b"
+        "llama-3.3-70b",
+        "deepseek-r1-distill-llama-70b"
     ]
-    model_aliases = {"llama-3.1-70b": default_model, "llama-3.1-8b": "llama3.1-8b"}
+    model_aliases = {"llama-3.1-70b": default_model, "llama-3.1-8b": "llama3.1-8b", "deepseek-r1": "deepseek-r1-distill-llama-70b"}
 
     @classmethod
     async def create_async_generator(


### PR DESCRIPTION
… list

Cerebras now provides inference for a DeepSeek-R1 distilled to Llama 3.3 70B as well.